### PR TITLE
Update REST VOL/HDF5 Dockerfiles

### DIFF
--- a/hdf5lib/Dockerfile
+++ b/hdf5lib/Dockerfile
@@ -10,9 +10,11 @@ RUN cd /tmp                                                                     
     rm ${HDF5_MINOR_REL}.tar                                                       ; \
     cd /usr/local/src/${HDF5_MINOR_REL}                                            ; \
     ./configure --prefix=/usr/local/hdf5                                           ; \
-    make                                                                           ; \
-    make install                                                                   ; \
-    make clean                                                                     ; \
+    mkdir build                                                                    ; \
+    cd build                                                                       ; \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local/hdf5                                   ; \
+    cmake --build . -j                                                             ; \
+    cmake --install .                                                              ; \
     rm -rf /usr/local/src/${HDF5_MINOR_REL}/*                                      ; \
     for f in /usr/local/hdf5/bin/* ; do ln -s $f /usr/local/bin ; done             ; \
     pip install cython                                                             ; \
@@ -22,10 +24,9 @@ RUN cd /tmp                                                                     
     git clone https://github.com/h5py/h5py.git                                     ; \
     cd h5py                                                                        ; \
     export HDF5_DIR=/usr/local/hdf5                                                ; \
-    python setup.py build                                                          ; \
     pip install -v .                                                               ; \
     cd -                                                                           ; \
     git clone https://github.com/HDFGroup/h5pyd.git                                ; \
     cd h5pyd                                                                       ; \
-    python setup.py install                                                        ; \
+    pip install -v . ; \
     cd -                                                                           

--- a/restvol/Dockerfile
+++ b/restvol/Dockerfile
@@ -1,21 +1,19 @@
-FROM centos
+FROM dokken/centos-stream-9
 MAINTAINER John Readey <jreadey@hdfgroup.org>                                                           
 RUN yum -y install gcc gcc-c++                                                        ; \
-    yum -y install yajl                                                               ; \
     yum -y install wget                                                               ; \
     yum -y install unzip                                                              ; \
     yum -y install make                                                               ; \
     yum -y install which                                                              ; \
-    yum -y install autofconf                                                          ; \
     yum -y install libtool                                                            ; \
     yum -y install curl-devel                                                         ; \
     yum -y install openssl-devel                                                      ; \
     yum -y install git                                                                
 RUN cd /tmp                                                                           ; \
-    wget https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2.tar.gz ;\
-    gunzip cmake-3.17.2.tar.gz                                                        ; \
-    tar -xvf cmake-3.17.2.tar                                                         ; \
-    cd cmake-3.17.2                                                                   ; \
+    wget https://github.com/Kitware/CMake/releases/download/v3.29.1/cmake-3.29.1.tar.gz ;\
+    gunzip cmake-3.29.1.tar.gz                                                        ; \
+    tar -xvf cmake-3.29.1.tar                                                         ; \
+    cd cmake-3.29.1                                                                   ; \
     ./bootstrap                                                                       ; \
     make                                                                              ; \
     make install                                                                      
@@ -31,9 +29,17 @@ RUN cd /usr/local/src                                                           
     cp yajl-2.1.1/lib/* /usr/local/lib                                                ; \
     cd /usr/local
 RUN cd /usr/local/src                                                                 ; \
-    git clone  https://github.com/HDFGroup/vol-rest -b  hdf5_1_12_update              ; \
+    git clone https://github.com/HDFGroup/hdf5                                        ; \
+    cd hdf5                                                                           ; \
+    mkdir build                                                                       ; \
+    cd build                                                                          ; \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIBS=OFF -DHDF5_ENABLE_Z_LIB_SUPPORT=OFF -DHDF5_ENABLE_SZIP_SUPPORT=OFF .. ; \
+    cmake --build . -j                                                                 ; \
+    cmake --install .
+RUN cd /usr/local/src                                                                 ; \
+    git clone  https://github.com/HDFGroup/vol-rest                                   ; \
     cd vol-rest                                                                       ; \
-    ./build_vol_cmake.sh -P /usr/
+    ./build_vol_cmake.sh -P /usr/local/
 
 
 


### PR DESCRIPTION
- HDF5 and REST VOL now both use CMake. Autotools isn't cross platform, and yum installs a version below the library's minimum requirement anyway (2.69 vs. 2.71)
- REST VOL Dockerfile uses CentOS Stream 9 since CentOS 8 is deprecated. This also fixes an issue with missing yum packages.
- h5py/h5pyd installation in HDF5 file no longer uses deprecated `setup.py`