### PR TITLE
Fix and update hdf5lib build

### DIFF
--- a/hdf5lib/Dockerfile
+++ b/hdf5lib/Dockerfile
@@ -7,46 +7,41 @@ ENV HDF5_SRC_URL         https://github.com/HDFGroup/hdf5/releases/download
 # Install the necessary packages
 RUN cd /tmp && \
     apt-get --yes update && \
-    apt-get --yes install cmake
-
+    apt-get --yes install cmake>=3.18.0 && \
 # Download the HDF5 source code
-RUN wget -q ${HDF5_SRC_URL}/${HDF5_MINOR_REL_URL}/hdf5.tar.gz && \
+    wget -q ${HDF5_SRC_URL}/${HDF5_MINOR_REL_URL}/hdf5.tar.gz && \
     tar -xzf hdf5.tar.gz --directory /usr/local/src && \
-    rm hdf5.tar.gz
-
+    rm hdf5.tar.gz && \
 # Configure the library
-RUN cd /usr/local/src/${HDF5_MINOR_REL_FOLDER} && \
+    cd /usr/local/src/${HDF5_MINOR_REL_FOLDER} && \
     mkdir build && \
     cd build && \
-    cmake -DHDF5_ENABLE_ROS3_VFD=ON -DCMAKE_INSTALL_PREFIX=/usr/local/hdf5 -S .. -B .
-
+    cmake -DHDF5_ENABLE_ROS3_VFD=ON -DCMAKE_INSTALL_PREFIX=/usr/local/hdf5 -S .. -B . && \
 # Build and install the library
-RUN cd /usr/local/src/${HDF5_MINOR_REL_FOLDER}/build && \
-    cmake --build . --config Release -j
-
-RUN cd /usr/local/src/${HDF5_MINOR_REL_FOLDER}/build && \
-    cmake --install .
-
-# Clean up
-RUN rm -rf /usr/local/src/${HDF5_MINOR_REL_FOLDER}/* 
-
+    cd /usr/local/src/${HDF5_MINOR_REL_FOLDER}/build && \
+    cmake --build . --config Release -j && \
+    cd /usr/local/src/${HDF5_MINOR_REL_FOLDER}/build && \
+    cmake --install . && \
+# Clean up build/src files
+    rm -rf /usr/local/src/${HDF5_MINOR_REL_FOLDER}/* && \
 # Set up executables
-RUN for f in /usr/local/hdf5/bin/* ; do ln -s $f /usr/local/bin ; done
-
+    for f in /usr/local/hdf5/bin/* ; do ln -s $f /usr/local/bin ; done && \
 # Install the necessary Python packages
-RUN pip install cython && \
-    pip install numpy && \
-    pip install s3fs
-
+    cd /usr/local/src && \
+    pip install cython==3.0.8 && \
+    pip install numpy\<2.0.0 && \
+    pip install s3fs==2024.6.1 && \
 # Install h5py
-RUN cd /usr/local/src && \
+    cd /usr/local/src && \
     git clone https://github.com/h5py/h5py.git && \
     cd h5py && \
     export HDF5_DIR=/usr/local/hdf5 && \
-    pip install -v .
-
+    pip install -v . && \
 # Install h5pyd
-RUN cd /usr/local/src && \
+    cd /usr/local/src && \
     git clone https://github.com/HDFGroup/h5pyd.git && \
     cd h5pyd && \
-    pip install -v .                                                             
+    pip install -v . && \
+# Final clean up
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/hdf5lib/Dockerfile
+++ b/hdf5lib/Dockerfile
@@ -1,35 +1,52 @@
 FROM python:3.10
-MAINTAINER John Readey <jreadey@hdfgroup.org>
-ENV HDF5_MAJOR_REL       hdf5-1.14
-ENV HDF5_MINOR_REL       hdf5-1.14.3
-ENV HDF5_SRC_URL   http://support.hdfgroup.org/ftp/HDF5/releases
-RUN cd /tmp                                                                        ; \
-    apt-get --yes update ;\
-    apt-get --yes install cmake ;\
-    echo "Getting: ${HDF5_SRC_URL}/${HDF5_MAJOR_REL}/${HDF5_MINOR_REL}/src/${HDF5_MINOR_REL}.tar"                ; \
-    wget -q ${HDF5_SRC_URL}/${HDF5_MAJOR_REL}/${HDF5_MINOR_REL}/src/${HDF5_MINOR_REL}.tar                        ; \
-    tar -xf ${HDF5_MINOR_REL}.tar --directory /usr/local/src                      ; \
-    rm ${HDF5_MINOR_REL}.tar                                                       ; \
-    cd /usr/local/src/${HDF5_MINOR_REL}                                            ; \
-    ./configure --prefix=/usr/local/hdf5                                           ; \
-    mkdir build                                                                    ; \
-    cd build                                                                       ; \
-    cmake -DCMAKE_INSTALL_PREFIX=/usr/local/hdf5                                   ; \
-    cmake --build . -j                                                             ; \
-    cmake --install .                                                              ; \
-    sleep 5 ; \
-    rm -rf /usr/local/src/${HDF5_MINOR_REL}/*                                      ; \
-    for f in /usr/local/hdf5/bin/* ; do ln -s $f /usr/local/bin ; done             ; \
-    pip install cython                                                             ; \
-    pip install numpy                                                              ; \
-    pip install s3fs                                                               ; \
-    cd /usr/local/src                                                              ; \
-    git clone https://github.com/h5py/h5py.git                                     ; \
-    cd h5py                                                                        ; \
-    export HDF5_DIR=/usr/local/hdf5                                                ; \
-    pip install -v .                                                               ; \
-    cd -                                                                           ; \
-    git clone https://github.com/HDFGroup/h5pyd.git                                ; \
-    cd h5pyd                                                                       ; \
-    pip install -v . ; \
-    cd -                                                                           
+LABEL maintainer="John Readey <jreadey@hdfgroup.org>"
+ENV HDF5_MINOR_REL_URL      hdf5_1.14.4.3
+ENV HDF5_MINOR_REL_FOLDER   hdf5-1.14.4-3
+ENV HDF5_SRC_URL         https://github.com/HDFGroup/hdf5/releases/download
+
+# Install the necessary packages
+RUN cd /tmp && \
+    apt-get --yes update && \
+    apt-get --yes install cmake
+
+# Download the HDF5 source code
+RUN wget -q ${HDF5_SRC_URL}/${HDF5_MINOR_REL_URL}/hdf5.tar.gz && \
+    tar -xzf hdf5.tar.gz --directory /usr/local/src && \
+    rm hdf5.tar.gz
+
+# Configure the library
+RUN cd /usr/local/src/${HDF5_MINOR_REL_FOLDER} && \
+    mkdir build && \
+    cd build && \
+    cmake -DHDF5_ENABLE_ROS3_VFD=ON -DCMAKE_INSTALL_PREFIX=/usr/local/hdf5 -S .. -B .
+
+# Build and install the library
+RUN cd /usr/local/src/${HDF5_MINOR_REL_FOLDER}/build && \
+    cmake --build . --config Release -j
+
+RUN cd /usr/local/src/${HDF5_MINOR_REL_FOLDER}/build && \
+    cmake --install .
+
+# Clean up
+RUN rm -rf /usr/local/src/${HDF5_MINOR_REL_FOLDER}/* 
+
+# Set up executables
+RUN for f in /usr/local/hdf5/bin/* ; do ln -s $f /usr/local/bin ; done
+
+# Install the necessary Python packages
+RUN pip install cython && \
+    pip install numpy && \
+    pip install s3fs
+
+# Install h5py
+RUN cd /usr/local/src && \
+    git clone https://github.com/h5py/h5py.git && \
+    cd h5py && \
+    export HDF5_DIR=/usr/local/hdf5 && \
+    pip install -v .
+
+# Install h5pyd
+RUN cd /usr/local/src && \
+    git clone https://github.com/HDFGroup/h5pyd.git && \
+    cd h5pyd && \
+    pip install -v .                                                             

--- a/restvol/Dockerfile
+++ b/restvol/Dockerfile
@@ -1,5 +1,6 @@
 FROM dokken/centos-stream-9
-MAINTAINER John Readey <jreadey@hdfgroup.org>                                                           
+LABEL maintainer="John Readey <jreadey@hdfgroup.org>"
+                                                       
 RUN yum -y install gcc gcc-c++                                                        ; \
     yum -y install wget                                                               ; \
     yum -y install unzip                                                              ; \


### PR DESCRIPTION
- Fix the cmake build process not targeting the root properly, resulting in build failure
- Bump HDF5 version from 1.14.3 to 1.14.4.3 The system for setting up version numbers in URLs changed, and has a special case for patches in the URL vs. resultant folder name.
- Enable ROS3 VFD
- Replace deprecated MAINTAINER